### PR TITLE
Hide other "continue in app" prompt in comments

### DIFF
--- a/src/webPlugins/CoreStyles.raw.css
+++ b/src/webPlugins/CoreStyles.raw.css
@@ -2,3 +2,11 @@
   display: none;
 }
 
+shreddit-experience-tree {
+  display: none;
+}
+
+body {
+  overflow: scroll !important;
+  pointer-events: auto !important;
+}


### PR DESCRIPTION
The "continue in app" prompt is differently implemented in comments threads compared to the main feed, needs different CSS to hide it.